### PR TITLE
Replaced input() with raw_input

### DIFF
--- a/Dir_create/Dir_create.py
+++ b/Dir_create/Dir_create.py
@@ -5,7 +5,7 @@ def ask_values(prompt, input_msg):
     choices = []
     print(f"{prompt} (press <ENTER> when finished)")
     while True:
-        choice = input(input_msg)
+        choice = raw_input(input_msg) #input("") is vulnerable to code exec
         if choice:
             choices.append(choice)
         else:


### PR DESCRIPTION
### 📊 Metadata *

https://huntr.dev/bounties/1-other-C0oki3s/python-tools/

#### Bounty URL: https://huntr.dev/bounties/1-other-C0oki3s/python-tools/

### ⚙️ Description *

Replace `input` with `raw_input` to avoid unwanted code execution.

### 💻 Technical Description *

https://intx0x80.blogspot.com/2017/05/python-input-vulnerability_25.html
In python 2.x `input(str)` is the equivalent of `eval(str)`. By using `raw_input` instead, you will prevent unsafe code execution.

### 🐛 Proof of Concept (PoC) *

When asked to enter your language for example, enter : `__import__("os").system("ls")`

### 🔥 Proof of Fix (PoF) *

Now that you use raw_input, your input won't be `eval()`-ed
